### PR TITLE
Introduce default Plan name, as a variable.

### DIFF
--- a/ama-plans/defaults.json
+++ b/ama-plans/defaults.json
@@ -1,4 +1,4 @@
 {
-  "plan_name": "on-demand",
+  "name": "on-demand",
   "version": "0.0.41"
 }

--- a/ama-plans/defaults.json
+++ b/ama-plans/defaults.json
@@ -1,0 +1,4 @@
+{
+  "plan_name": "on-demand",
+  "version": "0.0.41"
+}

--- a/ama-plans/planmeta.json
+++ b/ama-plans/planmeta.json
@@ -1,4 +1,0 @@
-{
-  "default_plan": "on-demand",
-  "recommended_version": "0.0.41"
-}

--- a/ama-plans/planmeta.json
+++ b/ama-plans/planmeta.json
@@ -1,0 +1,4 @@
+{
+  "default_plan": "on-demand",
+  "recommended_version": "0.0.41"
+}

--- a/ama-plans/version.json
+++ b/ama-plans/version.json
@@ -1,1 +1,4 @@
-{"recommended": "0.0.41"}
+{
+  "deprecated": "we had to add the plan name too, so this file has a terrible name",
+  "recommended": "0.0.41"
+}


### PR DESCRIPTION
We are about to change the plan name, so we need to introduce meta for the CLI to know the default.

Sadly, the CLI has a hard-coded `on-demand` in it: https://github.com/hashicorp/cloud-hcs-cli/blob/master/azext_hcs/custom.py#L100. The new plan name will be `on-demand-v2`. 

As such, we should introduce a new meta entry to fetch the default plan name (if one isnt supplied to the CLI). 

Due to this new meta, the file name `version.json` is wrong. As such, we'll introduce a new file `planmeta.json` with the expanded responsibility.
We will stop selling the `on-demand` plan after Tuesday Sept 15, 2020, and as such, old CLIs will break (missing plan), so deprecating the `version.json` file is less of a big deal, as old CLIs will break anyway. 

We can delete the version.json file shortly after stop sell. 

Full launch plan is [here](https://docs.google.com/document/d/1bmNG3FctPR35GXVEB2JMI5ujgm-71jVnbd5eLp6PnAQ/edit#heading=h.2l5nfwleie1e)