### PR TITLE
Switch default HCS plan to on-demand-v2

### DIFF
--- a/ama-plans/defaults.json
+++ b/ama-plans/defaults.json
@@ -1,4 +1,4 @@
 {
-  "name": "on-demand",
-  "version": "0.0.41"
+  "name": "on-demand-v2",
+  "version": "0.0.43"
 }

--- a/ama-plans/version.json
+++ b/ama-plans/version.json
@@ -1,4 +1,4 @@
 {
   "deprecated": "we had to add the plan name too, so this file has a terrible name",
-  "recommended": "0.0.41"
+  "recommended": "0.0.43"
 }


### PR DESCRIPTION
Microsoft released the new plan this night. This PR updates the version
that is installed by the HCS CLI when no explicit plan is provided.