### PR TITLE
Update default version to 0.0.49

### DIFF
--- a/ama-plans/defaults.json
+++ b/ama-plans/defaults.json
@@ -1,4 +1,4 @@
 {
   "name": "on-demand-v2",
-  "version": "0.0.46"
+  "version": "0.0.49"
 }


### PR DESCRIPTION
We have released updated packages to integration and production of version `0.0.49` and those publishes have completed.

Given that, let's update the `ama-plans` default version.