### PR TITLE
Use 0.0.54: which sets consul default version to 1.8.6 in the UI

### DIFF
--- a/ama-plans/defaults.json
+++ b/ama-plans/defaults.json
@@ -1,5 +1,5 @@
 {
   "name": "on-demand-v2",
-  "version": "0.0.53",
+  "version": "0.0.54",
   "ama_api_version": "2020-11-06"
 }

--- a/ama-plans/defaults.json
+++ b/ama-plans/defaults.json
@@ -1,5 +1,5 @@
 {
   "name": "on-demand-v2",
-  "version": "0.0.52",
+  "version": "0.0.53",
   "ama_api_version": "2020-11-06"
 }


### PR DESCRIPTION
Update the Azure UI dropdown box to contain 1.8.6 as the default value.

Contains: https://github.com/hashicorp/cloud-consul-ama-package/pull/126