### PR TITLE
[HCS-1632] Update hcs-meta AMA version to newest version 0.0.56

### DIFF
--- a/ama-plans/defaults.json
+++ b/ama-plans/defaults.json
@@ -1,5 +1,5 @@
 {
   "name": "on-demand-v2",
-  "version": "0.0.54",
+  "version": "0.0.56",
   "ama_api_version": "2020-11-06"
 }


### PR DESCRIPTION
Once the prod:

<img width="1515" alt="Screen Shot 2021-01-11 at 4 24 35 PM" src="https://user-images.githubusercontent.com/52710607/104245415-d8a4bf80-5429-11eb-8815-5fdbbe1fb266.png">

<img width="1420" alt="Screen Shot 2021-01-11 at 4 25 05 PM" src="https://user-images.githubusercontent.com/52710607/104245346-b3b04c80-5429-11eb-9ce1-dc615480c053.png">

and int offers:
<img width="1861" alt="Screen Shot 2021-01-11 at 4 25 23 PM" src="https://user-images.githubusercontent.com/52710607/104245370-c0cd3b80-5429-11eb-91c5-408514e2e4a6.png">
<img width="1337" alt="Screen Shot 2021-01-11 at 4 25 45 PM" src="https://user-images.githubusercontent.com/52710607/104245372-c165d200-5429-11eb-91bb-77fe4ddb3eca.png">
have completed publishing this can be merged in. 