### PR TITLE
HCS-1889: Bump AMA package version

### DIFF
--- a/ama-plans/defaults.json
+++ b/ama-plans/defaults.json
@@ -1,5 +1,5 @@
 {
   "name": "on-demand-v2",
-  "version": "0.0.58",
+  "version": "0.0.59",
   "ama_api_version": "2020-11-06"
 }


### PR DESCRIPTION
Tested by running:
```bash
curl -s https://raw.githubusercontent.com/hashicorp/cloud-hcs-meta/pcewing/bump-ama-version/ama-plans/defaults.json \
    | jq -r .version
# => 0.0.59
```