### PR TITLE
Bump HCS version to 0.0.63

### DIFF
--- a/ama-plans/defaults.json
+++ b/ama-plans/defaults.json
@@ -1,5 +1,5 @@
 {
   "name": "on-demand-v2",
-  "version": "0.0.61",
+  "version": "0.0.63",
   "ama_api_version": "2021-04-23"
 }


### PR DESCRIPTION
HCS publishing has finished for all 3 envs for this version so now we can bump the version here to have hcstest use this version.