### PR TITLE
Bump HCS app version to 0.0.64

### DIFF
--- a/ama-plans/defaults.json
+++ b/ama-plans/defaults.json
@@ -1,5 +1,5 @@
 {
   "name": "on-demand-v2",
-  "version": "0.0.63",
+  "version": "0.0.64",
   "ama_api_version": "2021-04-23"
 }


### PR DESCRIPTION
Now that all the HCS publishing has succeeded we can bump the version here 