### PR TITLE
Bump HCS app version

### DIFF
--- a/ama-plans/defaults.json
+++ b/ama-plans/defaults.json
@@ -1,5 +1,5 @@
 {
   "name": "on-demand-v2",
-  "version": "0.0.64",
+  "version": "0.0.65",
   "ama_api_version": "2021-04-23"
 }


### PR DESCRIPTION
Now that the MS publishing for version 0.0.65 is complete we can bump this.