### PR TITLE
bump HCS version to 0.0.67

### DIFF
--- a/ama-plans/defaults.json
+++ b/ama-plans/defaults.json
@@ -1,5 +1,5 @@
 {
   "name": "on-demand-v2",
-  "version": "0.0.65",
+  "version": "0.0.67",
   "ama_api_version": "2021-04-23"
 }


### PR DESCRIPTION
Had to skip 0.0.66 due to some bug in the azure portal that wasn't allowing me to publish that version again after cancelling it half way.