### PR TITLE
Bump default version

### DIFF
--- a/ama-plans/defaults.json
+++ b/ama-plans/defaults.json
@@ -1,5 +1,5 @@
 {
   "name": "on-demand-v2",
-  "version": "0.0.73",
+  "version": "0.0.76",
   "ama_api_version": "2021-04-23"
 }


### PR DESCRIPTION
Following the release guide, bumping default version for purposes of HCS testing: https://docs.google.com/document/d/1kuDqo_eZkYkWX3HPTvVUbKcIcsPnP9YM6xTXCgJMmeQ/edit#bookmark=id.3grsjorwwcc2

This version aligns with the one in Azure: https://partner.microsoft.com/en-us/dashboard/commercial-marketplace/offers/6b4277c8-11cc-4293-afee-b217c94fa55e/plans/02de6cdb-1c51-445d-bc1b-3535adb84139/technicalconfiguration