### PR TITLE
Revert "Revert "Bump default version""

### DIFF
--- a/ama-plans/defaults.json
+++ b/ama-plans/defaults.json
@@ -1,5 +1,5 @@
 {
   "name": "on-demand-v2",
-  "version": "0.0.73",
+  "version": "0.0.76",
   "ama_api_version": "2021-04-23"
 }


### PR DESCRIPTION
Reverts hashicorp/cloud-hcs-meta#27

Yesterday I bumped the default version of the AMA package. Then ran into an issue where only `on-demand-2` had been bumped not `annual` (my bad). Today, I verified both have been bumped to `0.0.76`: https://partner.microsoft.com/en-us/dashboard/commercial-marketplace/offers/6b4277c8-11cc-4293-afee-b217c94fa55e/overview

Context: https://hashicorp.slack.com/archives/C01ECLS7WCS/p1654189575492269